### PR TITLE
Fix pty prompt breaking when closing editor

### DIFF
--- a/install-comments-hook
+++ b/install-comments-hook
@@ -45,7 +45,7 @@ add_comments() {
         PATTERN="${PATTERN:${#SEPARATOR}}"
         EXCMD="set expandtab softtabstop=4 tabstop=4 shiftwidth=4"
         # Let vi search for the newly installed packages, redirect I/O to terminal
-        $VEDITOR -c "$EXCMD" +/"$PATTERN" "$PKGS_LOGFILE" < /dev/tty > /dev/tty
+        script -q -c "$VEDITOR -c '$EXCMD' '+/$PATTERN' '$PKGS_LOGFILE'" /dev/null < /dev/tty > /dev/tty
     else
         echo -e "\033[1;33mwarning:\033[0m vi not available -- add comments to ${PKGS_LOGFILE} manually"
     fi


### PR DESCRIPTION
When running the hook in a gui session, closing the editor breaks the terminal prompt and prints uninterpreted ANSI escape sequences, see the image below:
![pacman_ich_tty](https://github.com/user-attachments/assets/1f4424c5-f72c-42f5-82b2-46ad31a32fcc)

It seems to happen only when there are escape sequences in the prompt.
I assume that running $VEDITOR with the /dev/tty redirections does not correctly reset the terminal state when in a pty.

Running the editor with the script command seems to fix it. There's probably a better way to do this but it works.